### PR TITLE
feat: :sparkles: Sidebar starts collapsed on narrow screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <calcite-loader></calcite-loader>
     <calcite-shell>
       <wsdot-header slot="header"></wsdot-header>
-      <calcite-shell-panel slot="panel-start" id="sidebar">
+      <calcite-shell-panel slot="panel-start" id="sidebar" collapsed>
         <calcite-panel>
           <calcite-block
             heading="Enter State Route & Milepost"

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,11 @@ function setupSidebarCollapseButton(view: MapView) {
       setSidebarToggleIcon();
     });
 
+    // Set sidebar collapsed to false if document width is less than 768px.
+    if (window.outerWidth >= 768) {
+      sideBar.collapsed = false;
+    }
+
     view.ui.add(collapseButton, "top-leading");
 
     const setSidebarToggleIcon = () => {


### PR DESCRIPTION
Sidebar will now be collapsed on screens with a width less than 768px.