### PR TITLE
build: :zap: Load Calcite from CDN

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,7 +23,10 @@
 	],
 	"json.schemas": [
 		{
-			"fileMatch": [".ncurc", ".ncurc.json"],
+			"fileMatch": [
+				".ncurc",
+				".ncurc.json"
+			],
 			"url": "https://raw.githubusercontent.com/raineorshine/npm-check-updates/main/src/types/RunOptions.json"
 		}
 	],
@@ -35,7 +38,9 @@
 		"https://json.schemastore.org/github-workflow.json": [
 			".github/workflows/node.js.yml"
 		],
-		"https://json.schemastore.org/lefthook.json": ["lefthook.yml"],
+		"https://json.schemastore.org/lefthook.json": [
+			"lefthook.yml"
+		],
 		"https://raw.githubusercontent.com/raineorshine/npm-check-updates/main/src/types/RunOptions.json": [
 			".ncurc.yml"
 		]
@@ -46,5 +51,8 @@
 	},
 	"[json]": {
 		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"[html]": {
+		"editor.defaultFormatter": "vscode.html-language-features"
 	}
 }

--- a/index.html
+++ b/index.html
@@ -9,6 +9,10 @@
   <meta name="description"
     content="Locates mileposts along Washington State Routes, as defined by the Washington State Department of Transportation's Linear Referencing System." />
   <meta name="theme-color" content="#007b5f" />
+  <script src="https://js.arcgis.com/calcite-components/2.13.2/calcite.esm.js" type="module"
+    integrity="sha512-ZEFetRq7tY/JhuR5Q+CWfNAR94hzBrocMr7pFHmuaRmDjtE3/utjp8Vcscf7beoNvLbnVWJL99bVIYvPyudK2g=="
+    crossorigin="anonymous"></script>
+  <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/2.13.2/calcite.css" />
   <!-- 
     Contitionally load either the light or dark theme depending on user's settings.
     See https://blog.jim-nielsen.com/2019/conditional-syntax-highlighting-in-dark-mode-with-css-imports/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"description": "Milepost map written with ArcGIS Maps API for JavaScript",
 	"type": "module",
 	"scripts": {
-		"prepare": "tsx tools/copy-wsdot-webstyles.ts && tsx tools/copy-calcite-assets.ts",
+		"prepare": "tsx tools/copy-wsdot-webstyles.ts",
 		"build": "vite build",
 		"watch": "vite build -- --watch",
 		"preview": "vite preview",

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,11 +71,15 @@ import("./setupAnalytics")
 // Note that the method described in
 // https://developers.arcgis.com/calcite-design-system/get-started/#custom-elements
 // does not seem to work.
-const calciteAssetPath = `${import.meta.env.BASE_URL}/calcite/assets`;
-defineCustomElements(window, { resourcesUrl: calciteAssetPath });
+// const calciteAssetPath = `${import.meta.env.BASE_URL}/calcite/assets`;
+// defineCustomElements(window, { resourcesUrl: calciteAssetPath });
 
 // Setup interceptors for non-Calcite icons.
 // E.g., https://js.arcgis.com/calcite-components/2.13.0/assets/icon/usRouteShield16.json
+
+defineCustomElements(window, {
+	resourcesUrl: "https://js.arcgis.com/calcite-components/2.13.2/assets",
+});
 
 /**
  * Determines the host environment based on the location hostname.

--- a/src/widgets/route-input/createComboBoxItems.ts
+++ b/src/widgets/route-input/createComboBoxItems.ts
@@ -46,23 +46,6 @@ export function getRoutes(
 }
 
 /**
- * Gets the appropriate icon name for the route shield.
- * @param shield - The shield of the route.
- * @returns The appropriate icon name for the route shield.
- */
-function getRouteShieldIconName(
-	shield: NonNullable<InstanceType<typeof RouteDescription>["shield"]>,
-): `${`${"wa" | "us"}-route` | "interstate"}-shield` {
-	if (/^I/i.test(shield)) {
-		return "interstate-shield";
-	}
-	if (/^US$/i.test(shield)) {
-		return "us-route-shield";
-	}
-	return "wa-route-shield";
-}
-
-/**
  * Generates a generator function that yields a sequence of calcite-combobox-item elements
  * based on the provided routes map. Each calcite-combobox-item element contains a routeId
  * and a empty-string-separated string of directions associated with that routeId.
@@ -81,9 +64,6 @@ export function* getComboboxItems(routes: Map<string, string[]>) {
 			shield += " ";
 		}
 
-		const icon = routeDescription.shield
-			? getRouteShieldIconName(routeDescription.shield)
-			: null;
 		element.description = `${shield}${Number.parseInt(routeDescription.sr)}`;
 		if (routeDescription.rrt) {
 			element.description += ` ${routeDescription.rrtDescription}`;
@@ -92,21 +72,17 @@ export function* getComboboxItems(routes: Map<string, string[]>) {
 			}
 		}
 
-		if (icon) {
-			element.icon = icon;
-		}
 		element.guid = routeId;
 		element.value = routeId;
 		element.heading = routeId;
 		element.label = routeId;
 		/*
-    Use "text-label" instead of "shortHeading".
-    "shortHeading" will add an extra column
-    to the calcite-combobox-item that we don't
-    want.
-    */
+		Use "text-label" instead of "shortHeading".
+		"shortHeading" will add an extra column
+		to the calcite-combobox-item that we don't
+		want.
+		*/
 		element.setAttribute("text-label", routeId);
-		// element.shortHeading = routeId;
 		element.dataset.directions = directions.join("");
 		yield element;
 	}


### PR DESCRIPTION
Calcite is now, once again, loaded from CDN to
improve build times and reduce bundle size.

However, this means that we can no longer have
our custom icons in the State Route dropdown.