### PR TITLE
test: :white_check_mark: Fixed URL parsing to fix failing test

### DIFF
--- a/src/elc/url.ts
+++ b/src/elc/url.ts
@@ -288,7 +288,7 @@ export function getElcParamsFromUrl(
 
 	const { srmp: endSrmp, back: endBack } = emp
 		? parseSrmp(emp)
-		: { srmp: null, back: null };
+		: { srmp: undefined, back: undefined };
 	const output = {
 		Route: route,
 		Srmp: srmp,


### PR DESCRIPTION
Modified URL parsing so that endSrmp and endBack are returned as `undefined` rather than `null` when no end milepost is specified to match previous behavior. The previous version actually worked in the app but was causing the unit test to fail.